### PR TITLE
Fix Moneta::Adapters::Redis delete method

### DIFF
--- a/spec/moneta/adapters/redis/adapter_redis_spec.rb
+++ b/spec/moneta/adapters/redis/adapter_redis_spec.rb
@@ -28,8 +28,7 @@ describe 'adapter_redis', adapter: :Redis do
       end
 
       it 'returns nil' do
-        allow(store.backend).to receive(:get).and_return(nil)
-        expect(store.delete(nil)).to eq(nil)
+        expect(store.delete('non_existent_key')).to eq(nil)
       end
     end
   end

--- a/spec/moneta/adapters/redis/adapter_redis_spec.rb
+++ b/spec/moneta/adapters/redis/adapter_redis_spec.rb
@@ -27,7 +27,7 @@ describe 'adapter_redis', adapter: :Redis do
         Moneta::Adapters::Redis.new(host: redis_host, port: redis_port, db: 6)
       end
 
-      it do
+      it 'returns nil' do
         allow(store.backend).to receive(:get).and_return(nil)
         expect(store.delete(nil)).to eq(nil)
       end


### PR DESCRIPTION
This PR fixes the case where a `value` method is being invoked on a nil response from a Redis `delete` command, which occurs because the key being deleted doesn't already exist.

